### PR TITLE
Clean up exhibitionLabelText

### DIFF
--- a/src/modules/processingFiles/objects/index.js
+++ b/src/modules/processingFiles/objects/index.js
@@ -691,6 +691,12 @@ const parseItem = item => {
     if (newItem[field] && JSON.stringify(newItem[field]) === emptyJSON) newItem[field] = null
   })
 
+  // clean up exhibitionLabelText
+  if (newItem['exhibition'] && 
+      newItem['exhibition']['exhibitionLabelText'] && 
+      JSON.stringify(newItem['exhibition']['exhibitionLabelText']) === emptyJSON)
+    newItem['exhibition']['exhibitionLabelText'] = null
+
   return newItem
 }
 


### PR DESCRIPTION
Clean up `exhibitionLabelText` and so that the content is clear in Elasticsearch when there is no content is source file