### PR TITLE
Use Auth 0 user search_engine v3

### DIFF
--- a/src/classes/user/index.js
+++ b/src/classes/user/index.js
@@ -23,6 +23,9 @@ const getUserSync = async id => {
 
   const user = await request({
       url: `https://${auth0info.AUTH0_DOMAIN}/api/v2/users/${id}`,
+      qs: {
+        search_engine: 'v3'
+      },
       method: 'GET',
       headers: {
         'content-type': 'application/json',
@@ -67,6 +70,9 @@ const setApiToken = async id => {
 
   const user = await request({
       url: `https://${auth0info.AUTH0_DOMAIN}/api/v2/users/${id}`,
+      qs: {
+        search_engine: 'v3'
+      },
       method: 'PATCH',
       headers: {
         'content-type': 'application/json',
@@ -113,6 +119,9 @@ const setRoles = async (id, roles) => {
 
   const user = await request({
       url: `https://${auth0info.AUTH0_DOMAIN}/api/v2/users/${id}`,
+      qs: {
+        search_engine: 'v3'
+      },
       method: 'PATCH',
       headers: {
         'content-type': 'application/json',
@@ -145,6 +154,9 @@ const setLang = async (id, lang) => {
 
   const user = await request({
       url: `https://${auth0info.AUTH0_DOMAIN}/api/v2/users/${id}`,
+      qs: {
+        search_engine: 'v3'
+      },
       method: 'PATCH',
       headers: {
         'content-type': 'application/json',

--- a/src/classes/users/index.js
+++ b/src/classes/users/index.js
@@ -25,7 +25,8 @@ class Users {
     for (const page of pages) {
       const qs = {
         per_page: perPage,
-        page
+        page,
+        search_engine: 'v3'
       }
       const users = await request({
         url: `https://${auth0info.AUTH0_DOMAIN}/api/v2/users`,

--- a/src/modules/auth0/index.js
+++ b/src/modules/auth0/index.js
@@ -82,7 +82,7 @@ const getAllUserTokens = async (page) => {
     fields: 'user_id,user_metadata',
     per_page: 100,
     page: page,
-    search_engine: 'v2'
+    search_engine: 'v3'
   }
   const users = await request({
     url: `https://${auth0info.AUTH0_DOMAIN}/api/v2/users`,


### PR DESCRIPTION
From Auth0:

The User Search v2 engine is deprecated, please use v3 (search_engine=v3) instead. For guidance on how to upgrade from v2 to v3, see: https://auth0.com/docs/users/search/v3/migrate-search-v2-v3

To ensure that your queries are using search engine v3 prior to v2 becoming unavailable, you must update all your calls to the `GET /api/v2/users` endpoint to include the `search_engine=v3` parameter. This will enable you to see whether any queries need to be updated, so that you will not experience downtime when v2 becomes unavailable.